### PR TITLE
Resize historical drilldown labels on smaller screens, instead of hiding

### DIFF
--- a/pmp/static/css/pmp.css
+++ b/pmp/static/css/pmp.css
@@ -152,6 +152,11 @@ rect.pane {
     border-radius: 7px;
 }
 
+.historical-drilldown > div {
+	width: 25%;
+	display: inline-block;
+}
+
 /*
  *Chains
  *Currently not available from frontend

--- a/pmp/static/js/directives/historical-linear.js
+++ b/pmp/static/js/directives/historical-linear.js
@@ -429,19 +429,19 @@
                     }
                     scope.labelData = [{
                         label: 'Time: ',
-                        style: 'color: #90a4ae; position: absolute; left: 0px',
+                        style: 'color: #90a4ae;',
                         data: tmp
                     }, {
                         label: 'Expected events: ',
-                        style: 'color: #263238; position: absolute; left: 250px',
+                        style: 'color: #263238;',
                         data: data[1]
                     }, {
                         label: 'Events in DAS: ',
-                        style: 'color: #ff6f00; position: absolute; left: 450px',
+                        style: 'color: #ff6f00;',
                         data: data[2]
                     }, {
                         label: 'Done events in DAS: ',
-                        style: 'color: #01579b; position: absolute; left: 650px',
+                        style: 'color: #01579b;',
                         data: data[3]
                     }];
                 };

--- a/pmp/static/partials/data-label.html
+++ b/pmp/static/partials/data-label.html
@@ -1,8 +1,8 @@
-<div ng-if="!taskChain" class="hidden-sm hidden-xs">
-  <span ng-repeat="d in labelData" style="{{d.style}}">{{d.label}}
+<div ng-if="!taskChain" class="historical-drilldown">
+  <div ng-repeat="d in labelData" style="{{d.style}}">{{d.label}}
     <span ng-if="humanReadableNumbers && d.label != 'Time: '">{{d.data | readableNumbers}}</span>
     <span ng-if="!humanReadableNumbers || d.label == 'Time: '">{{d.data}}</span>
-  </span>
+  </div>
 </div>
 <div ng-if="taskChain" class="col-lg-12 hidden-sm hidden-xs">
   <ul class="nav nav-pills">


### PR DESCRIPTION
Resolves issue #41 