### PR TITLE
Include the `lumisection` attributes and OpenSearch migration

### DIFF
--- a/fetchd/default.conf
+++ b/fetchd/default.conf
@@ -12,7 +12,7 @@ url = https://cmsweb.cern.ch/couchdb/reqmgr_workload_cache/
 [workflows]
 source_db = http://vocms074:5984/requests/
 source_db_changes = http://vocms074:5984/requests/_changes?since
-fetch_fields = TotalEvents, OutputDatasets, PrepID, RequestName, RequestType, EventNumberHistory, RequestTransition, ProcessingString
+fetch_fields = TotalEvents, TotalInputLumis, OutputDatasets, PrepID, RequestName, RequestType, EventNumberHistory, RequestTransition, ProcessingString
 mapping = {"properties":{"prepid": {"type": "text", "analyzer": "keyword"}}}
 pmp_index = workflows/
 pmp_type = workflow/
@@ -60,7 +60,7 @@ pmp_type = relval_cmssw_version/
 [requests]
 source_db = http://vocms0490:5984/requests/
 source_db_changes = http://vocms0490:5984/requests/_changes?since
-fetch_fields = dataset_name, datatiers, flown_with, history, interested_pwg, member_of_campaign, member_of_chain, output_dataset, ppd_tags, prepid, priority, pwg, reqmgr_name, reqmgr_status_history, status, tags, time_event, total_events
+fetch_fields = dataset_name, datatiers, flown_with, history, interested_pwg, member_of_campaign, member_of_chain, output_dataset, ppd_tags, prepid, priority, pwg, reqmgr_name, reqmgr_status_history, status, tags, time_event, total_events, total_input_lumis
 mapping = {"properties": {"dataset_name": {"type": "text", "analyzer": "keyword"}, "datatiers": {"type": "text", "analyzer": "keyword"}, "flown_with": {"type": "text", "analyzer": "keyword"}, "interested_pwd": {"type": "text", "analyzer": "keyword"}, "member_of_campaign": {"type": "text", "analyzer": "keyword"}, "member_of_chain": {"type": "text", "analyzer": "keyword"}, "output_dataset": {"type": "text", "analyzer": "keyword"}, "ppd_tags": {"type": "text", "analyzer": "keyword"}, "prepid": {"type": "text", "analyzer": "keyword"}, "reqmgr_name": {"type": "text", "analyzer": "keyword"}, "status": {"type": "text", "analyzer": "keyword"}, "tags": {"type": "text", "analyzer": "keyword"}}}
 pmp_index = requests/
 pmp_type = request/

--- a/fetchd/fetch.py
+++ b/fetchd/fetch.py
@@ -24,6 +24,7 @@ def rename_attributes(index, data, config):
                         'RequestName': 'request_name',
                         'RequestTransition': 'request_transition',
                         'RequestType': 'request_type',
+                        'TotalInputLumis': 'total_input_lumis',
                         'TotalEvents': 'total_events'}
     else:
         return data
@@ -57,8 +58,10 @@ def parse_workflows_history(history):
             dataset_events['time'] = entry_time
             dataset_events['events'] = dataset_events['Events']
             dataset_events['type'] = dataset_events['Type']
+            dataset_events['lumis'] = dataset_events.get('Lumis', 0)
             del dataset_events['Events']
             del dataset_events['Type']
+            dataset_events.pop('Lumis', '')
             if dataset_name not in parsed:
                 parsed[dataset_name] = []
 
@@ -287,7 +290,14 @@ def create_fake_request(stats_doc, cfg):
 
     if workflow_name == fake_request['reqmgr_name'][-1]:
         # If this is the newest workflow, update things
+        logging.info(
+            'Workflow %s is the newest for the request, updating it. Stats2 type: %s',
+            workflow_name,
+            stats_doc.get('RequestType', '<unknown>')
+        )
         fake_request['total_events'] = stats_doc['TotalEvents']
+        # If the Stats2 record has the lumis data, include, otherwise set zero
+        fake_request['total_input_lumis'] = stats_doc.get('TotalInputLumis', 0)
         fake_request['priority'] = stats_doc['RequestPriority']
         if len(stats_doc['Campaigns']) > 0:
             campaign = stats_doc['Campaigns'][0]

--- a/fetchd/fetch.py
+++ b/fetchd/fetch.py
@@ -58,10 +58,15 @@ def parse_workflows_history(history):
             dataset_events['time'] = entry_time
             dataset_events['events'] = dataset_events['Events']
             dataset_events['type'] = dataset_events['Type']
-            dataset_events['lumis'] = dataset_events.get('Lumis', 0)
             del dataset_events['Events']
             del dataset_events['Type']
-            dataset_events.pop('Lumis', '')
+
+            # Lumisections
+            lumis_available = dataset_events.get('Lumis')
+            if lumis_available:
+                dataset_events['lumis'] = lumis_available
+                dataset_events.pop('Lumis', '')    
+
             if dataset_name not in parsed:
                 parsed[dataset_name] = []
 
@@ -296,8 +301,12 @@ def create_fake_request(stats_doc, cfg):
             stats_doc.get('RequestType', '<unknown>')
         )
         fake_request['total_events'] = stats_doc['TotalEvents']
+
         # If the Stats2 record has the lumis data, include, otherwise set zero
-        fake_request['total_input_lumis'] = stats_doc.get('TotalInputLumis', 0)
+        total_input_lumis = stats_doc.get('TotalInputLumis')
+        if total_input_lumis:
+            fake_request['total_input_lumis'] = total_input_lumis
+
         fake_request['priority'] = stats_doc['RequestPriority']
         if len(stats_doc['Campaigns']) > 0:
             campaign = stats_doc['Campaigns'][0]

--- a/pmp/api/historical.py
+++ b/pmp/api/historical.py
@@ -167,9 +167,12 @@ class HistoricalAPI(APIBase):
                 found_something = True
                 # create an array of requests to be processed
                 response = {'data': [{'produced': 0,
+                                      'produced_lumis': 0,
                                       'done': 0,
+                                      'done_lumis': 0,
                                       'invalid': 0,
                                       'expected': int(mcm_document['expected']),
+                                      'expected_lumis': int(mcm_document.get('total_input_lumis', 0)),
                                       'time': int(mcm_document['submitted_time'])}]}
 
                 response['request'] = mcm_document['prepid']
@@ -216,9 +219,12 @@ class HistoricalAPI(APIBase):
                             for entry in history:
                                 data_point = {
                                     'produced': 0,
+                                    'produced_lumis': 0,
                                     'done': 0,
+                                    'done_lumis': 0,
                                     'invalid': 0,
                                     'expected': mcm_document.get('expected', 0),
+                                    'expected_lumis': mcm_document.get('total_input_lumis', 0),
                                     'time': entry['time'],
                                     'expected_events': True
                                 }
@@ -229,12 +235,15 @@ class HistoricalAPI(APIBase):
                                     data_point['expected_events'] = False
 
                                 events = entry.get('events', 0)
+                                lumis = entry.get('lumis', 0)
                                 if entry['type'] in types_for_done_events:
                                     data_point['done'] = events
+                                    data_point['done_lumis'] = lumis
                                 elif entry['type'] in types_for_invalid_events:
                                     data_point['invalid'] = events
                                 else:
                                     data_point['produced'] = events
+                                    data_point['produced_lumis'] = lumis
 
                                 response['data'].append(data_point)
 
@@ -321,7 +330,7 @@ class HistoricalAPI(APIBase):
 
             data_points = sorted(request.get('data', []), key=lambda k: k['time'])
             if not data_points:
-                data_points = [{'done': 0, 'produced': 0}]
+                data_points = [{'done': 0, 'done_lumis': 0, 'produced': 0, 'produced_lumis': 0}]
 
             workflow_name = ''
             if len(request.get('reqmgr_name', [])) > 0:
@@ -333,7 +342,9 @@ class HistoricalAPI(APIBase):
                              'output_dataset_status': request['output_dataset_status'],
                              'dataset': request['dataset'],
                              'expected': data_points[-1]['expected'],
+                             'expected_lumis': data_points[-1]['expected_lumis'],
                              'done': max(data_points[-1]['done'], data_points[-1]['produced'], data_points[-1]['invalid']),
+                             'done_lumis': max(data_points[-1]['done_lumis'], data_points[-1]['produced_lumis']),
                              'force_completed': request['force_completed'],
                              'estimate_from': request.get('estimate_from', None),
                              'workflow': workflow_name,

--- a/pmp/api/historical.py
+++ b/pmp/api/historical.py
@@ -292,8 +292,11 @@ class HistoricalAPI(APIBase):
         prev = {'produced': -1, 'expected': -1}
         for data_point in arr:
             if (data_point['produced'] != prev['produced'] or
+                data_point.get('produced_lumis') != prev.get('produced_lumis') or
                 data_point['expected'] != prev['expected'] or
+                data_point.get('expected_lumis') != prev.get('expected_lumis') or
                 data_point['done'] != prev['done'] or
+                data_point.get('done_lumis') != prev.get('done_lumis') or
                 data_point['invalid'] != prev['invalid']):
                 compressed.append(data_point)
                 prev = data_point

--- a/pmp/static/js/controllers/historical.js
+++ b/pmp/static/js/controllers/historical.js
@@ -215,6 +215,7 @@ angular.module('pmpApp').controller('HistoricalController', ['$http',
                     data.data.results.submitted_requests.forEach(function(entry) {
                         entry.url = $scope.getUrlForPrepid(entry.prepid, entry.workflow);
                         entry.percentage = entry.done / entry.expected * 100;
+                        entry.percentageLumis = (entry.done_lumis / Math.max(entry.expected_lumis, 1)) * 100;
                         entry.statusTimestamp = now - entry.status_timestamp;
                         entry.statusTimestampDate = dateFormat(entry.status_timestamp, "yyyy-mm-dd HH:MM");
                         entry.statusTimestampDiff = $scope.secondsToDiff(now - entry.status_timestamp);
@@ -226,6 +227,7 @@ angular.module('pmpApp').controller('HistoricalController', ['$http',
                     data.data.results.done_requests.forEach(function(entry) {
                         entry.url = $scope.getUrlForPrepid(entry.prepid, entry.workflow);
                         entry.percentage = entry.done / entry.expected * 100;
+                        entry.percentageLumis = (entry.done_lumis / Math.max(entry.expected_lumis, 1)) * 100;
                         entry.statusTimestamp = now - entry.status_timestamp;
                         entry.statusTimestampDate = dateFormat(entry.status_timestamp, "yyyy-mm-dd HH:MM");
                         entry.statusTimestampDiff = $scope.secondsToDiff(now - entry.status_timestamp);

--- a/pmp/static/js/controllers/historical.js
+++ b/pmp/static/js/controllers/historical.js
@@ -32,6 +32,7 @@ angular.module('pmpApp').controller('HistoricalController', ['$http',
             sortSubmittedOrder: 1, // Sort ascending (1) or descending (-1)
             sortDoneOn: 'prepid', // Field to sort done list on
             sortDoneOrder: 1, // Sort ascending (1) or descending (-1)
+            display: '', // Two options only 'events' or 'lumis' for lumisections.
         };
 
         /**
@@ -69,6 +70,18 @@ angular.module('pmpApp').controller('HistoricalController', ['$http',
             $scope.sortDoneOn = urlParameters.sortDoneOn;
 
             $scope.sortDoneOrder = parseInt(urlParameters.sortDoneOrder, 10) === -1 ? -1 : 1;
+
+            // Display either 'events' or 'lumis'
+            if (urlParameters.display === 'lumis') {
+                $scope.display = 'lumis';
+                $scope.displayTitle = 'Lumisections';
+                $scope.counterTitle = 'events';
+            }
+            else {
+                $scope.display = 'events';
+                $scope.displayTitle = 'Events';
+                $scope.counterTitle = 'lumisections';
+            }
 
             // initialise filters
             if (urlParameters.priority !== undefined) {
@@ -214,26 +227,50 @@ angular.module('pmpApp').controller('HistoricalController', ['$http',
                     let now = parseInt(Date.now() / 1000);
                     data.data.results.submitted_requests.forEach(function(entry) {
                         entry.url = $scope.getUrlForPrepid(entry.prepid, entry.workflow);
-                        entry.percentage = entry.done / entry.expected * 100;
-                        entry.percentageLumis = (entry.done_lumis / Math.max(entry.expected_lumis, 1)) * 100;
                         entry.statusTimestamp = now - entry.status_timestamp;
                         entry.statusTimestampDate = dateFormat(entry.status_timestamp, "yyyy-mm-dd HH:MM");
                         entry.statusTimestampDiff = $scope.secondsToDiff(now - entry.status_timestamp);
                         entry.workflowStatus = entry.workflow_status;
                         entry.workflowTimestamp = now - entry.workflow_status_timestamp;
                         entry.workflowTimestampDiff = $scope.secondsToDiff(entry.workflow_timestamp <= 0 ? 0 : entry.workflowTimestamp);
+
+                        // Set the events or lumisections following the option chosen.
+                        if ($scope.display === 'lumis') {
+                            // Use lumisections
+                            entry.displayDone = entry.done_lumis;
+                            entry.displayExpected = entry.expected_lumis;
+                        }
+                        else {
+                            // Use events
+                            entry.displayDone = entry.done;
+                            entry.displayExpected = entry.expected;
+                        }
+                        // Set the progress percentage
+                        entry.displayPercentage = (entry.displayDone / Math.max(entry.displayExpected, 1)) * 100;
                     });
                     $scope.listSubmitted = data.data.results.submitted_requests.sort($scope.compareSubmitted);
                     data.data.results.done_requests.forEach(function(entry) {
                         entry.url = $scope.getUrlForPrepid(entry.prepid, entry.workflow);
-                        entry.percentage = entry.done / entry.expected * 100;
-                        entry.percentageLumis = (entry.done_lumis / Math.max(entry.expected_lumis, 1)) * 100;
                         entry.statusTimestamp = now - entry.status_timestamp;
                         entry.statusTimestampDate = dateFormat(entry.status_timestamp, "yyyy-mm-dd HH:MM");
                         entry.statusTimestampDiff = $scope.secondsToDiff(now - entry.status_timestamp);
                         entry.workflowStatus = entry.workflow_status;
                         entry.workflowTimestamp = now - entry.workflow_status_timestamp;
                         entry.workflowTimestampDiff = $scope.secondsToDiff(entry.workflow_timestamp <= 0 ? 0 : entry.workflowTimestamp);
+
+                        // Set the events or lumisections following the option chosen.
+                        if ($scope.display === 'lumis') {
+                            // Use lumisections
+                            entry.displayDone = entry.done_lumis;
+                            entry.displayExpected = entry.expected_lumis;
+                        }
+                        else {
+                            // Use events
+                            entry.displayDone = entry.done;
+                            entry.displayExpected = entry.expected;
+                        }
+                        // Set the progress percentage
+                        entry.displayPercentage = (entry.displayDone / Math.max(entry.displayExpected, 1)) * 100;
                     });
                     $scope.listDone = data.data.results.done_requests.sort($scope.compareDone);
                     $scope.data = Data.getLoadedData();
@@ -319,6 +356,17 @@ angular.module('pmpApp').controller('HistoricalController', ['$http',
             }
             $scope.listDone = $scope.listDone.sort($scope.compareDone);
             $scope.setURL($scope, Data);
+        }
+
+        $scope.displayEventsLumis = function() {
+            if ($scope.display === 'lumis') {
+                $scope.display = 'events';
+            }
+            else {
+                $scope.display = 'lumis';
+            }
+            $scope.setURL($scope, Data);
+            $scope.init();
         }
 
         $scope.$on('onChangeNotification:InputTags', function () {

--- a/pmp/static/js/controllers/main.js
+++ b/pmp/static/js/controllers/main.js
@@ -208,7 +208,7 @@ angular.module('pmpApp').controller('MainController', ['$http', '$location',
             $location.search(params).replace();
             $scope.$broadcast('onChangeNotification:URL');
             var urlQuery = ''
-            var keys = ['r', 'pwg', 'interested_pwg', 'status', 'priority', 'display']
+            var keys = ['r', 'pwg', 'interested_pwg', 'status', 'priority']
             keys.forEach(function (param) {
                 if (param in params) {
                     if (urlQuery.length == 0) {

--- a/pmp/static/js/controllers/main.js
+++ b/pmp/static/js/controllers/main.js
@@ -208,7 +208,7 @@ angular.module('pmpApp').controller('MainController', ['$http', '$location',
             $location.search(params).replace();
             $scope.$broadcast('onChangeNotification:URL');
             var urlQuery = ''
-            var keys = ['r', 'pwg', 'interested_pwg', 'status', 'priority']
+            var keys = ['r', 'pwg', 'interested_pwg', 'status', 'priority', 'display']
             keys.forEach(function (param) {
                 if (param in params) {
                     if (urlQuery.length == 0) {

--- a/pmp/static/partials/historical.html
+++ b/pmp/static/partials/historical.html
@@ -5,23 +5,19 @@
                      human-readable-numbers="humanReadable"
                      big-number-formatter="formatBigNumber"
                      class="spacing"><div class="historical-drilldown" id="historical-drilldown"></div></linear-lifetime>
-    <button type="button" class="btn btn-primary" ng-click="displayEventsLumis()">Switch to {{counterTitle}}</button>
     <div ng-if="listSubmitted.length != 0">
       <p class="mt-4">
         List of requests (<b>{{listSubmitted.length}}</b>) in status <b>submitted</b>
       </p>
       <div class="row small-padding">
-        <!-- Top bar buttons -->
         <div class="col-sm-5">
           <button type="button" class="btn btn-sort m-2" ng-click="changeSubmittedSort('prepid')">
-            <!-- Request prepid -->
             <i ng-if="sortSubmittedOn != 'prepid'" class="fa fa-sort-amount-asc spacing-r" title="Click to sort ascending by prepid"></i>
             <i ng-if="sortSubmittedOn == 'prepid' && sortSubmittedOrder == 1" class="fa fa-sort-amount-asc spacing-r sort-selected" title="Click to sort descending by prepid"></i>
             <i ng-if="sortSubmittedOn == 'prepid' && sortSubmittedOrder == -1" class="fa fa-sort-amount-desc spacing-r sort-selected" title="Click to sort ascending by prepid"></i>
           </button>
         </div>
         <div class="col-sm-2">
-          <!-- Events or lumisections -->
           <button type="button" class="btn btn-sort m-2" ng-click="changeSubmittedSort('displayDone')">
             <i ng-if="sortSubmittedOn != 'displayDone'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by done events/lumisections"></i>
             <i ng-if="sortSubmittedOn == 'displayDone' && sortSubmittedOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by done events/lumisections"></i>
@@ -35,7 +31,6 @@
           </button>
         </div>
         <div class="col-sm-1">
-          <!-- Progress bar -->
           <button type="button" class="btn btn-sort m-2" ng-click="changeSubmittedSort('displayPercentage')">
             <i ng-if="sortSubmittedOn != 'displayPercentage'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by progress"></i>
             <i ng-if="sortSubmittedOn == 'displayPercentage' && sortSubmittedOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by progress"></i>
@@ -43,7 +38,6 @@
           </button>
         </div>
         <div class="col-sm-2">
-          <!-- ReqMgr2 status -->
           <button type="button" class="btn btn-sort m-2" ng-click="changeSubmittedSort('workflowTimestamp')">
             <i ng-if="sortSubmittedOn != 'workflowTimestamp'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by time in current workflow status"></i>
             <i ng-if="sortSubmittedOn == 'workflowTimestamp' && sortSubmittedOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by time in current workflow status"></i>
@@ -51,7 +45,6 @@
           </button>
         </div>
         <div class="col-sm-1">
-          <!-- Priority -->
           <button type="button" class="btn btn-sort m-2" ng-click="changeSubmittedSort('priority')">
             <i ng-if="sortSubmittedOn != 'priority'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by priority"></i>
             <i ng-if="sortSubmittedOn == 'priority' && sortSubmittedOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by priority"></i>
@@ -66,13 +59,11 @@
           <small title="Number of events estimated from {{submitted.estimate_from}}" style="color:red" ng-if="submitted.estimate_from"><br>(Estimate from {{submitted.estimate_from}})</small>
         </div>
         <div class="col-sm-2">
-          <small>{{displayTitle}}:</small><br>
-          <div ng-show="submitted.displayExpected > 0">
-            <b title="{{submitted.displayDone}}">{{humanReadable ? (submitted.displayDone | readableNumbers) : submitted.displayDone}}</b>
-            <small title="Force completed" style="color:red" ng-if="submitted.force_completed">(FC)</small>
-            /
-            <b title="{{submitted.displayExpected}}">{{humanReadable ? (submitted.displayExpected | readableNumbers) : submitted.displayExpected}}</b>
-          </div>
+          <small>{{submitted.display}}:</small><br>
+          <b title="{{submitted.displayDone}}">{{humanReadable ? (submitted.displayDone | readableNumbers) : submitted.displayDone}}</b>
+          <small title="Force completed" style="color:red" ng-if="submitted.force_completed">(FC)</small>
+          /
+          <b title="{{submitted.displayExpected}}">{{humanReadable ? (submitted.displayExpected | readableNumbers) : submitted.displayExpected}}</b>
         </div>
         <div class="col-sm-1">
           <small>Progress:</small><br>
@@ -124,23 +115,23 @@
           </button>
         </div>
         <div class="col-sm-2">
-          <button type="button" class="btn btn-sort m-2" ng-click="changeDoneSort('displayDone')">
-            <i ng-if="sortDoneOn != 'displayDone'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by done events/lumisections"></i>
-            <i ng-if="sortDoneOn == 'displayDone' && sortDoneOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by done events/lumisections"></i>
-            <i ng-if="sortDoneOn == 'displayDone' && sortDoneOrder == -1" class="fa fa-sort-numeric-desc spacing-r sort-selected" title="Click to sort ascending by done events/lumisections"></i>
+          <button type="button" class="btn btn-sort m-2" ng-click="changeSubmittedSort('displayDone')">
+            <i ng-if="sortSubmittedOn != 'displayDone'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by done events/lumisections"></i>
+            <i ng-if="sortSubmittedOn == 'displayDone' && sortSubmittedOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by done events/lumisections"></i>
+            <i ng-if="sortSubmittedOn == 'displayDone' && sortSubmittedOrder == -1" class="fa fa-sort-numeric-desc spacing-r sort-selected" title="Click to sort ascending by done events/lumisections"></i>
           </button>
           /
-          <button type="button" class="btn btn-sort m-2" ng-click="changeDoneSort('displayExpected')">
-            <i ng-if="sortDoneOn != 'displayExpected'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by expected events/lumisections"></i>
-            <i ng-if="sortDoneOn == 'displayExpected' && sortDoneOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by expected events/lumisections"></i>
-            <i ng-if="sortDoneOn == 'displayExpected' && sortDoneOrder == -1" class="fa fa-sort-numeric-desc spacing-r sort-selected" title="Click to sort ascending by expected events/lumisections"></i>
+          <button type="button" class="btn btn-sort m-2" ng-click="changeSubmittedSort('displayExpected')">
+            <i ng-if="sortSubmittedOn != 'displayExpected'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by expected events/lumisections"></i>
+            <i ng-if="sortSubmittedOn == 'displayExpected' && sortSubmittedOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by expected events/lumisections"></i>
+            <i ng-if="sortSubmittedOn == 'displayExpected' && sortSubmittedOrder == -1" class="fa fa-sort-numeric-desc spacing-r sort-selected" title="Click to sort ascending by expected events/lumisections"></i>
           </button>
         </div>
         <div class="col-sm-1">
-          <button type="button" class="btn btn-sort m-2" ng-click="changeDoneSort('displayPercentage')">
-            <i ng-if="sortDoneOn != 'displayPercentage'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by progress"></i>
-            <i ng-if="sortDoneOn == 'displayPercentage' && sortDoneOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by progress"></i>
-            <i ng-if="sortDoneOn == 'displayPercentage' && sortDoneOrder == -1" class="fa fa-sort-numeric-desc spacing-r sort-selected" title="Click to sort ascending by progress"></i>
+          <button type="button" class="btn btn-sort m-2" ng-click="changeSubmittedSort('displayPercentage')">
+            <i ng-if="sortSubmittedOn != 'displayPercentage'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by progress"></i>
+            <i ng-if="sortSubmittedOn == 'displayPercentage' && sortSubmittedOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by progress"></i>
+            <i ng-if="sortSubmittedOn == 'displayPercentage' && sortSubmittedOrder == -1" class="fa fa-sort-numeric-desc spacing-r sort-selected" title="Click to sort ascending by progress"></i>
           </button>
         </div>
         <div class="col-sm-2">
@@ -165,13 +156,11 @@
           <small title="Number of events estimated from {{done.estimate_from}}" style="color:red" ng-if="done.estimate_from"><br>(Estimate from {{done.estimate_from}})</small>
         </div>
         <div class="col-sm-2">
-          <small>{{displayTitle}}:</small><br>
-          <div ng-show="done.displayExpected > 0">
-            <b title="{{done.displayDone}}">{{humanReadable ? (done.displayDone | readableNumbers) : done.displayDone}}</b>
-            <small title="Force completed" style="color:red" ng-if="done.force_completed">(FC)</small>
-            /
-            <b title="{{done.displayExpected}}">{{humanReadable ? (done.displayExpected | readableNumbers) : done.displayExpected}}</b>
-          </div>
+          <small>{{done.display}}:</small><br>
+          <b title="{{done.displayDone}}">{{humanReadable ? (done.displayDone | readableNumbers) : done.displayDone}}</b>
+          <small title="Force completed" style="color:red" ng-if="done.force_completed">(FC)</small>
+          /
+          <b title="{{done.displayExpected}}">{{humanReadable ? (done.displayExpected | readableNumbers) : done.displayExpected}}</b>
         </div>
         <div class="col-sm-1">
           <small>Progress:</small><br>

--- a/pmp/static/partials/historical.html
+++ b/pmp/static/partials/historical.html
@@ -10,7 +10,7 @@
         List of requests (<b>{{listSubmitted.length}}</b>) in status <b>submitted</b>
       </p>
       <div class="row small-padding">
-        <div class="col-sm-5">
+        <div class="col-sm-2">
           <button type="button" class="btn btn-sort m-2" ng-click="changeSubmittedSort('prepid')">
             <i ng-if="sortSubmittedOn != 'prepid'" class="fa fa-sort-amount-asc spacing-r" title="Click to sort ascending by prepid"></i>
             <i ng-if="sortSubmittedOn == 'prepid' && sortSubmittedOrder == 1" class="fa fa-sort-amount-asc spacing-r sort-selected" title="Click to sort descending by prepid"></i>
@@ -18,6 +18,7 @@
           </button>
         </div>
         <div class="col-sm-2">
+          <!-- Events -->
           <button type="button" class="btn btn-sort m-2" ng-click="changeSubmittedSort('done')">
             <i ng-if="sortSubmittedOn != 'done'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by done events"></i>
             <i ng-if="sortSubmittedOn == 'done' && sortSubmittedOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by done events"></i>
@@ -30,11 +31,34 @@
             <i ng-if="sortSubmittedOn == 'expected' && sortSubmittedOrder == -1" class="fa fa-sort-numeric-desc spacing-r sort-selected" title="Click to sort ascending by expected events"></i>
           </button>
         </div>
+        <div class="col-sm-2">
+          <!-- Lumisections -->
+          <button type="button" class="btn btn-sort m-2" ng-click="changeSubmittedSort('done_lumis')">
+            <i ng-if="sortSubmittedOn != 'done_lumis'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by done lumisections"></i>
+            <i ng-if="sortSubmittedOn == 'done_lumis' && sortSubmittedOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by done lumisections"></i>
+            <i ng-if="sortSubmittedOn == 'done_lumis' && sortSubmittedOrder == -1" class="fa fa-sort-numeric-desc spacing-r sort-selected" title="Click to sort ascending by done lumisections"></i>
+          </button>
+          /
+          <button type="button" class="btn btn-sort m-2" ng-click="changeSubmittedSort('expected_lumis')">
+            <i ng-if="sortSubmittedOn != 'expected_lumis'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by expected lumisections"></i>
+            <i ng-if="sortSubmittedOn == 'expected_lumis' && sortSubmittedOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by expected lumisections"></i>
+            <i ng-if="sortSubmittedOn == 'expected_lumis' && sortSubmittedOrder == -1" class="fa fa-sort-numeric-desc spacing-r sort-selected" title="Click to sort ascending by expected lumisections"></i>
+          </button>
+        </div>
         <div class="col-sm-1">
+          <!-- Progress (Events) -->
           <button type="button" class="btn btn-sort m-2" ng-click="changeSubmittedSort('percentage')">
-            <i ng-if="sortSubmittedOn != 'percentage'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by progress"></i>
-            <i ng-if="sortSubmittedOn == 'percentage' && sortSubmittedOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by progress"></i>
-            <i ng-if="sortSubmittedOn == 'percentage' && sortSubmittedOrder == -1" class="fa fa-sort-numeric-desc spacing-r sort-selected" title="Click to sort ascending by progress"></i>
+            <i ng-if="sortSubmittedOn != 'percentage'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by progress (based on events)"></i>
+            <i ng-if="sortSubmittedOn == 'percentage' && sortSubmittedOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by progress (based on events)"></i>
+            <i ng-if="sortSubmittedOn == 'percentage' && sortSubmittedOrder == -1" class="fa fa-sort-numeric-desc spacing-r sort-selected" title="Click to sort ascending by progress (based on events)"></i>
+          </button>
+        </div>
+        <div class="col-sm-1">
+          <!-- Progress (Lumisections) -->
+          <button type="button" class="btn btn-sort m-2" ng-click="changeSubmittedSort('percentageLumis')">
+            <i ng-if="sortSubmittedOn != 'percentageLumis'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by progress (based on lumis)"></i>
+            <i ng-if="sortSubmittedOn == 'percentageLumis' && sortSubmittedOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by progress (based on lumis)"></i>
+            <i ng-if="sortSubmittedOn == 'percentageLumis' && sortSubmittedOrder == -1" class="fa fa-sort-numeric-desc spacing-r sort-selected" title="Click to sort ascending by progress (based on lumis)"></i>
           </button>
         </div>
         <div class="col-sm-2">
@@ -53,7 +77,7 @@
         </div>
       </div>
       <div ng-repeat="submitted in listSubmitted" class="row zebra-lines small-padding">
-        <div class="col-sm-5">
+        <div class="col-sm-2">
           <a ng-href="{{submitted.url}}" target="_blank">{{submitted.prepid}}</a>
           <br><small>{{submitted.dataset}}</small>
           <small title="Number of events estimated from {{submitted.estimate_from}}" style="color:red" ng-if="submitted.estimate_from"><br>(Estimate from {{submitted.estimate_from}})</small>
@@ -65,8 +89,16 @@
           /
           <b title="{{submitted.expected}}">{{humanReadable ? (submitted.expected | readableNumbers) : submitted.expected}}</b>
         </div>
+        <div class="col-sm-2">
+          <small>Lumisections:</small><br>
+          <b title="{{submitted.done_lumis}}">{{humanReadable ? (submitted.done_lumis | readableNumbers) : submitted.done_lumis}}</b>
+          <small title="Force completed" style="color:red" ng-if="submitted.force_completed">(FC)</small>
+          /
+          <b title="{{submitted.expected_lumis}}">{{humanReadable ? (submitted.expected_lumis | readableNumbers) : submitted.expected_lumis}}</b>
+        </div>
         <div class="col-sm-1">
-          <small>Progress:</small><br>
+          <!-- Progress (on events) -->
+          <small>Progress (events):</small><br>
           <div class="progress total-bar" ng-show="submitted.expected > 0">
             <div class="font-shadow progress-bar pmp-orange"
                  ng-class="{'pmp-red': submitted.output_dataset_status == 'INVALID' || submitted.output_dataset_status == 'DELETED',
@@ -80,6 +112,25 @@
                         max-width: 100%;
                         width:{{submitted.percentage}}%;">
               {{submitted.percentage | readableNumbers}}%
+            </div>
+          </div>
+        </div>
+        <div class="col-sm-1">
+          <!-- Progress (on lumisections) -->
+          <small>Progress (lumis):</small><br>
+          <div class="progress total-bar" ng-show="submitted.expected > 0">
+            <div class="font-shadow progress-bar pmp-orange"
+                 ng-class="{'pmp-red': submitted.output_dataset_status == 'INVALID' || submitted.output_dataset_status == 'DELETED',
+                            'pmp-blue': submitted.output_dataset_status == 'VALID',
+                            'pmp-orange': submitted.output_dataset_status == 'PRODUCTION'}"
+                 role="progressbar"
+                 aria-valuemin="0"
+                 aria-valuemax="100"
+                 title="{{submitted.output_dataset}} is {{submitted.output_dataset_status}} at {{submitted.percentageLumis | readableNumbers}}%"
+                 style="color: black;
+                        max-width: 100%;
+                        width:{{submitted.percentageLumis}}%;">
+              {{submitted.percentageLumis | readableNumbers}}%
             </div>
           </div>
         </div>
@@ -107,7 +158,7 @@
         List of requests (<b>{{listDone.length}}</b>) in status <b>done</b>
       </p>
       <div class="row small-padding">
-        <div class="col-sm-5">
+        <div class="col-sm-2">
           <button type="button" class="btn btn-sort m-2" ng-click="changeDoneSort('prepid')">
             <i ng-if="sortDoneOn != 'prepid'" class="fa fa-sort-amount-asc spacing-r" title="Click to sort ascending by prepid"></i>
             <i ng-if="sortDoneOn == 'prepid' && sortDoneOrder == 1" class="fa fa-sort-amount-asc spacing-r sort-selected" title="Click to sort descending by prepid"></i>
@@ -115,6 +166,7 @@
           </button>
         </div>
         <div class="col-sm-2">
+          <!-- Events -->
           <button type="button" class="btn btn-sort m-2" ng-click="changeDoneSort('done')">
             <i ng-if="sortDoneOn != 'done'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by done events"></i>
             <i ng-if="sortDoneOn == 'done' && sortDoneOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by done events"></i>
@@ -127,11 +179,34 @@
             <i ng-if="sortDoneOn == 'expected' && sortDoneOrder == -1" class="fa fa-sort-numeric-desc spacing-r sort-selected" title="Click to sort ascending by expected events"></i>
           </button>
         </div>
+        <div class="col-sm-2">
+          <!-- Lumisections -->
+          <button type="button" class="btn btn-sort m-2" ng-click="changeDoneSort('done_lumis')">
+            <i ng-if="sortDoneOn != 'done_lumis'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by done lumisections"></i>
+            <i ng-if="sortDoneOn == 'done_lumis' && sortDoneOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by done lumisections"></i>
+            <i ng-if="sortDoneOn == 'done_lumis' && sortDoneOrder == -1" class="fa fa-sort-numeric-desc spacing-r sort-selected" title="Click to sort ascending by done lumisections"></i>
+          </button>
+          /
+          <button type="button" class="btn btn-sort m-2" ng-click="changeDoneSort('expected_lumis')">
+            <i ng-if="sortDoneOn != 'expected_lumis'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by expected lumisections"></i>
+            <i ng-if="sortDoneOn == 'expected_lumis' && sortDoneOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by expected lumisections"></i>
+            <i ng-if="sortDoneOn == 'expected_lumis' && sortDoneOrder == -1" class="fa fa-sort-numeric-desc spacing-r sort-selected" title="Click to sort ascending by expected lumisections"></i>
+          </button>
+        </div>
         <div class="col-sm-1">
+          <!-- Progress (Events) -->
           <button type="button" class="btn btn-sort m-2" ng-click="changeDoneSort('percentage')">
-            <i ng-if="sortDoneOn != 'percentage'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by progress"></i>
-            <i ng-if="sortDoneOn == 'percentage' && sortDoneOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by progress"></i>
-            <i ng-if="sortDoneOn == 'percentage' && sortDoneOrder == -1" class="fa fa-sort-numeric-desc spacing-r sort-selected" title="Click to sort ascending by progress"></i>
+            <i ng-if="sortDoneOn != 'percentage'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by progress (based on events)"></i>
+            <i ng-if="sortDoneOn == 'percentage' && sortDoneOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by progress (based on events)"></i>
+            <i ng-if="sortDoneOn == 'percentage' && sortDoneOrder == -1" class="fa fa-sort-numeric-desc spacing-r sort-selected" title="Click to sort ascending by progress (based on events)"></i>
+          </button>
+        </div>
+        <div class="col-sm-1">
+          <!-- Progress (Lumisections) -->
+          <button type="button" class="btn btn-sort m-2" ng-click="changeDoneSort('percentageLumis')">
+            <i ng-if="sortDoneOn != 'percentageLumis'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by progress (based on lumis)"></i>
+            <i ng-if="sortDoneOn == 'percentageLumis' && sortDoneOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by progress (based on lumis)"></i>
+            <i ng-if="sortDoneOn == 'percentageLumis' && sortDoneOrder == -1" class="fa fa-sort-numeric-desc spacing-r sort-selected" title="Click to sort ascending by progress (based on lumis)"></i>
           </button>
         </div>
         <div class="col-sm-2">
@@ -150,7 +225,7 @@
         </div>
       </div>
       <div ng-repeat="done in listDone" class="row zebra-lines small-padding">
-        <div class="col-sm-5">
+        <div class="col-sm-2">
           <a ng-href="{{done.url}}" target="_blank">{{done.prepid}}</a>
           <br><small>{{done.dataset}}</small>
           <small title="Number of events estimated from {{done.estimate_from}}" style="color:red" ng-if="done.estimate_from"><br>(Estimate from {{done.estimate_from}})</small>
@@ -162,7 +237,15 @@
           /
           <b title="{{done.expected}}">{{humanReadable ? (done.expected | readableNumbers) : done.expected}}</b>
         </div>
+        <div class="col-sm-2">
+          <small>Lumisections:</small><br>
+          <b title="{{done.done_lumis}}">{{humanReadable ? (done.done_lumis | readableNumbers) : done.done_lumis}}</b>
+          <small title="Force completed" style="color:red" ng-if="done.force_completed">(FC)</small>
+          /
+          <b title="{{done.expected_lumis}}">{{humanReadable ? (done.expected_lumis | readableNumbers) : done.expected_lumis}}</b>
+        </div>
         <div class="col-sm-1">
+          <!-- Progress (on events) -->
           <small>Progress:</small><br>
           <div class="progress total-bar" ng-show="done.expected > 0">
             <div class="font-shadow progress-bar pmp-blue"
@@ -177,6 +260,25 @@
                         max-width: 100%;
                         width:{{done.percentage}}%;">
               {{done.percentage | readableNumbers}}%
+            </div>
+          </div>
+        </div>
+        <div class="col-sm-1">
+          <!-- Progress (on lumisections) -->
+          <small>Progress:</small><br>
+          <div class="progress total-bar" ng-show="done.expected > 0">
+            <div class="font-shadow progress-bar pmp-blue"
+                 ng-class="{'pmp-red': done.output_dataset_status == 'INVALID' || done.output_dataset_status == 'DELETED',
+                            'pmp-blue': done.output_dataset_status == 'VALID',
+                            'pmp-orange': done.output_dataset_status == 'PRODUCTION'}"
+                 role="progressbar"
+                 aria-valuemin="0"
+                 aria-valuemax="100"
+                 title="{{done.output_dataset}} is {{done.output_dataset_status}} at {{done.percentageLumis | readableNumbers}}%"
+                 style="color: black;
+                        max-width: 100%;
+                        width:{{done.percentageLumis}}%;">
+              {{done.percentageLumis | readableNumbers}}%
             </div>
           </div>
         </div>

--- a/pmp/static/partials/historical.html
+++ b/pmp/static/partials/historical.html
@@ -5,63 +5,45 @@
                      human-readable-numbers="humanReadable"
                      big-number-formatter="formatBigNumber"
                      class="spacing"><div class="historical-drilldown" id="historical-drilldown"></div></linear-lifetime>
+    <button type="button" class="btn btn-primary" ng-click="displayEventsLumis()">Switch to {{counterTitle}}</button>
     <div ng-if="listSubmitted.length != 0">
       <p class="mt-4">
         List of requests (<b>{{listSubmitted.length}}</b>) in status <b>submitted</b>
       </p>
       <div class="row small-padding">
-        <div class="col-sm-2">
+        <!-- Top bar buttons -->
+        <div class="col-sm-5">
           <button type="button" class="btn btn-sort m-2" ng-click="changeSubmittedSort('prepid')">
+            <!-- Request prepid -->
             <i ng-if="sortSubmittedOn != 'prepid'" class="fa fa-sort-amount-asc spacing-r" title="Click to sort ascending by prepid"></i>
             <i ng-if="sortSubmittedOn == 'prepid' && sortSubmittedOrder == 1" class="fa fa-sort-amount-asc spacing-r sort-selected" title="Click to sort descending by prepid"></i>
             <i ng-if="sortSubmittedOn == 'prepid' && sortSubmittedOrder == -1" class="fa fa-sort-amount-desc spacing-r sort-selected" title="Click to sort ascending by prepid"></i>
           </button>
         </div>
         <div class="col-sm-2">
-          <!-- Events -->
-          <button type="button" class="btn btn-sort m-2" ng-click="changeSubmittedSort('done')">
-            <i ng-if="sortSubmittedOn != 'done'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by done events"></i>
-            <i ng-if="sortSubmittedOn == 'done' && sortSubmittedOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by done events"></i>
-            <i ng-if="sortSubmittedOn == 'done' && sortSubmittedOrder == -1" class="fa fa-sort-numeric-desc spacing-r sort-selected" title="Click to sort ascending by done events"></i>
+          <!-- Events or lumisections -->
+          <button type="button" class="btn btn-sort m-2" ng-click="changeSubmittedSort('displayDone')">
+            <i ng-if="sortSubmittedOn != 'displayDone'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by done events/lumisections"></i>
+            <i ng-if="sortSubmittedOn == 'displayDone' && sortSubmittedOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by done events/lumisections"></i>
+            <i ng-if="sortSubmittedOn == 'displayDone' && sortSubmittedOrder == -1" class="fa fa-sort-numeric-desc spacing-r sort-selected" title="Click to sort ascending by done events/lumisections"></i>
           </button>
           /
-          <button type="button" class="btn btn-sort m-2" ng-click="changeSubmittedSort('expected')">
-            <i ng-if="sortSubmittedOn != 'expected'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by expected events"></i>
-            <i ng-if="sortSubmittedOn == 'expected' && sortSubmittedOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by expected events"></i>
-            <i ng-if="sortSubmittedOn == 'expected' && sortSubmittedOrder == -1" class="fa fa-sort-numeric-desc spacing-r sort-selected" title="Click to sort ascending by expected events"></i>
-          </button>
-        </div>
-        <div class="col-sm-2">
-          <!-- Lumisections -->
-          <button type="button" class="btn btn-sort m-2" ng-click="changeSubmittedSort('done_lumis')">
-            <i ng-if="sortSubmittedOn != 'done_lumis'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by done lumisections"></i>
-            <i ng-if="sortSubmittedOn == 'done_lumis' && sortSubmittedOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by done lumisections"></i>
-            <i ng-if="sortSubmittedOn == 'done_lumis' && sortSubmittedOrder == -1" class="fa fa-sort-numeric-desc spacing-r sort-selected" title="Click to sort ascending by done lumisections"></i>
-          </button>
-          /
-          <button type="button" class="btn btn-sort m-2" ng-click="changeSubmittedSort('expected_lumis')">
-            <i ng-if="sortSubmittedOn != 'expected_lumis'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by expected lumisections"></i>
-            <i ng-if="sortSubmittedOn == 'expected_lumis' && sortSubmittedOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by expected lumisections"></i>
-            <i ng-if="sortSubmittedOn == 'expected_lumis' && sortSubmittedOrder == -1" class="fa fa-sort-numeric-desc spacing-r sort-selected" title="Click to sort ascending by expected lumisections"></i>
+          <button type="button" class="btn btn-sort m-2" ng-click="changeSubmittedSort('displayExpected')">
+            <i ng-if="sortSubmittedOn != 'displayExpected'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by expected events/lumisections"></i>
+            <i ng-if="sortSubmittedOn == 'displayExpected' && sortSubmittedOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by expected events/lumisections"></i>
+            <i ng-if="sortSubmittedOn == 'displayExpected' && sortSubmittedOrder == -1" class="fa fa-sort-numeric-desc spacing-r sort-selected" title="Click to sort ascending by expected events/lumisections"></i>
           </button>
         </div>
         <div class="col-sm-1">
-          <!-- Progress (Events) -->
-          <button type="button" class="btn btn-sort m-2" ng-click="changeSubmittedSort('percentage')">
-            <i ng-if="sortSubmittedOn != 'percentage'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by progress (based on events)"></i>
-            <i ng-if="sortSubmittedOn == 'percentage' && sortSubmittedOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by progress (based on events)"></i>
-            <i ng-if="sortSubmittedOn == 'percentage' && sortSubmittedOrder == -1" class="fa fa-sort-numeric-desc spacing-r sort-selected" title="Click to sort ascending by progress (based on events)"></i>
-          </button>
-        </div>
-        <div class="col-sm-1">
-          <!-- Progress (Lumisections) -->
-          <button type="button" class="btn btn-sort m-2" ng-click="changeSubmittedSort('percentageLumis')">
-            <i ng-if="sortSubmittedOn != 'percentageLumis'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by progress (based on lumis)"></i>
-            <i ng-if="sortSubmittedOn == 'percentageLumis' && sortSubmittedOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by progress (based on lumis)"></i>
-            <i ng-if="sortSubmittedOn == 'percentageLumis' && sortSubmittedOrder == -1" class="fa fa-sort-numeric-desc spacing-r sort-selected" title="Click to sort ascending by progress (based on lumis)"></i>
+          <!-- Progress bar -->
+          <button type="button" class="btn btn-sort m-2" ng-click="changeSubmittedSort('displayPercentage')">
+            <i ng-if="sortSubmittedOn != 'displayPercentage'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by progress"></i>
+            <i ng-if="sortSubmittedOn == 'displayPercentage' && sortSubmittedOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by progress"></i>
+            <i ng-if="sortSubmittedOn == 'displayPercentage' && sortSubmittedOrder == -1" class="fa fa-sort-numeric-desc spacing-r sort-selected" title="Click to sort ascending by progress"></i>
           </button>
         </div>
         <div class="col-sm-2">
+          <!-- ReqMgr2 status -->
           <button type="button" class="btn btn-sort m-2" ng-click="changeSubmittedSort('workflowTimestamp')">
             <i ng-if="sortSubmittedOn != 'workflowTimestamp'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by time in current workflow status"></i>
             <i ng-if="sortSubmittedOn == 'workflowTimestamp' && sortSubmittedOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by time in current workflow status"></i>
@@ -69,6 +51,7 @@
           </button>
         </div>
         <div class="col-sm-1">
+          <!-- Priority -->
           <button type="button" class="btn btn-sort m-2" ng-click="changeSubmittedSort('priority')">
             <i ng-if="sortSubmittedOn != 'priority'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by priority"></i>
             <i ng-if="sortSubmittedOn == 'priority' && sortSubmittedOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by priority"></i>
@@ -77,48 +60,23 @@
         </div>
       </div>
       <div ng-repeat="submitted in listSubmitted" class="row zebra-lines small-padding">
-        <div class="col-sm-2">
+        <div class="col-sm-5">
           <a ng-href="{{submitted.url}}" target="_blank">{{submitted.prepid}}</a>
           <br><small>{{submitted.dataset}}</small>
           <small title="Number of events estimated from {{submitted.estimate_from}}" style="color:red" ng-if="submitted.estimate_from"><br>(Estimate from {{submitted.estimate_from}})</small>
         </div>
         <div class="col-sm-2">
-          <small>Events:</small><br>
-          <b title="{{submitted.done}}">{{humanReadable ? (submitted.done | readableNumbers) : submitted.done}}</b>
-          <small title="Force completed" style="color:red" ng-if="submitted.force_completed">(FC)</small>
-          /
-          <b title="{{submitted.expected}}">{{humanReadable ? (submitted.expected | readableNumbers) : submitted.expected}}</b>
-        </div>
-        <div class="col-sm-2">
-          <small>Lumisections:</small><br>
-          <b title="{{submitted.done_lumis}}">{{humanReadable ? (submitted.done_lumis | readableNumbers) : submitted.done_lumis}}</b>
-          <small title="Force completed" style="color:red" ng-if="submitted.force_completed">(FC)</small>
-          /
-          <b title="{{submitted.expected_lumis}}">{{humanReadable ? (submitted.expected_lumis | readableNumbers) : submitted.expected_lumis}}</b>
-        </div>
-        <div class="col-sm-1">
-          <!-- Progress (on events) -->
-          <small>Progress (events):</small><br>
-          <div class="progress total-bar" ng-show="submitted.expected > 0">
-            <div class="font-shadow progress-bar pmp-orange"
-                 ng-class="{'pmp-red': submitted.output_dataset_status == 'INVALID' || submitted.output_dataset_status == 'DELETED',
-                            'pmp-blue': submitted.output_dataset_status == 'VALID',
-                            'pmp-orange': submitted.output_dataset_status == 'PRODUCTION'}"
-                 role="progressbar"
-                 aria-valuemin="0"
-                 aria-valuemax="100"
-                 title="{{submitted.output_dataset}} is {{submitted.output_dataset_status}} at {{submitted.percentage | readableNumbers}}%"
-                 style="color: black;
-                        max-width: 100%;
-                        width:{{submitted.percentage}}%;">
-              {{submitted.percentage | readableNumbers}}%
-            </div>
+          <small>{{displayTitle}}:</small><br>
+          <div ng-show="submitted.displayExpected > 0">
+            <b title="{{submitted.displayDone}}">{{humanReadable ? (submitted.displayDone | readableNumbers) : submitted.displayDone}}</b>
+            <small title="Force completed" style="color:red" ng-if="submitted.force_completed">(FC)</small>
+            /
+            <b title="{{submitted.displayExpected}}">{{humanReadable ? (submitted.displayExpected | readableNumbers) : submitted.displayExpected}}</b>
           </div>
         </div>
         <div class="col-sm-1">
-          <!-- Progress (on lumisections) -->
-          <small>Progress (lumis):</small><br>
-          <div class="progress total-bar" ng-show="submitted.expected > 0">
+          <small>Progress:</small><br>
+          <div class="progress total-bar" ng-show="submitted.displayExpected > 0">
             <div class="font-shadow progress-bar pmp-orange"
                  ng-class="{'pmp-red': submitted.output_dataset_status == 'INVALID' || submitted.output_dataset_status == 'DELETED',
                             'pmp-blue': submitted.output_dataset_status == 'VALID',
@@ -126,11 +84,11 @@
                  role="progressbar"
                  aria-valuemin="0"
                  aria-valuemax="100"
-                 title="{{submitted.output_dataset}} is {{submitted.output_dataset_status}} at {{submitted.percentageLumis | readableNumbers}}%"
+                 title="{{submitted.output_dataset}} is {{submitted.output_dataset_status}} at {{submitted.displayPercentage | readableNumbers}}%"
                  style="color: black;
                         max-width: 100%;
-                        width:{{submitted.percentageLumis}}%;">
-              {{submitted.percentageLumis | readableNumbers}}%
+                        width:{{submitted.displayPercentage}}%;">
+              {{submitted.displayPercentage | readableNumbers}}%
             </div>
           </div>
         </div>
@@ -158,7 +116,7 @@
         List of requests (<b>{{listDone.length}}</b>) in status <b>done</b>
       </p>
       <div class="row small-padding">
-        <div class="col-sm-2">
+        <div class="col-sm-5">
           <button type="button" class="btn btn-sort m-2" ng-click="changeDoneSort('prepid')">
             <i ng-if="sortDoneOn != 'prepid'" class="fa fa-sort-amount-asc spacing-r" title="Click to sort ascending by prepid"></i>
             <i ng-if="sortDoneOn == 'prepid' && sortDoneOrder == 1" class="fa fa-sort-amount-asc spacing-r sort-selected" title="Click to sort descending by prepid"></i>
@@ -166,47 +124,23 @@
           </button>
         </div>
         <div class="col-sm-2">
-          <!-- Events -->
-          <button type="button" class="btn btn-sort m-2" ng-click="changeDoneSort('done')">
-            <i ng-if="sortDoneOn != 'done'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by done events"></i>
-            <i ng-if="sortDoneOn == 'done' && sortDoneOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by done events"></i>
-            <i ng-if="sortDoneOn == 'done' && sortDoneOrder == -1" class="fa fa-sort-numeric-desc spacing-r sort-selected" title="Click to sort ascending by done events"></i>
+          <button type="button" class="btn btn-sort m-2" ng-click="changeDoneSort('displayDone')">
+            <i ng-if="sortDoneOn != 'displayDone'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by done events/lumisections"></i>
+            <i ng-if="sortDoneOn == 'displayDone' && sortDoneOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by done events/lumisections"></i>
+            <i ng-if="sortDoneOn == 'displayDone' && sortDoneOrder == -1" class="fa fa-sort-numeric-desc spacing-r sort-selected" title="Click to sort ascending by done events/lumisections"></i>
           </button>
           /
-          <button type="button" class="btn btn-sort m-2" ng-click="changeDoneSort('expected')">
-            <i ng-if="sortDoneOn != 'expected'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by expected events"></i>
-            <i ng-if="sortDoneOn == 'expected' && sortDoneOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by expected events"></i>
-            <i ng-if="sortDoneOn == 'expected' && sortDoneOrder == -1" class="fa fa-sort-numeric-desc spacing-r sort-selected" title="Click to sort ascending by expected events"></i>
-          </button>
-        </div>
-        <div class="col-sm-2">
-          <!-- Lumisections -->
-          <button type="button" class="btn btn-sort m-2" ng-click="changeDoneSort('done_lumis')">
-            <i ng-if="sortDoneOn != 'done_lumis'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by done lumisections"></i>
-            <i ng-if="sortDoneOn == 'done_lumis' && sortDoneOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by done lumisections"></i>
-            <i ng-if="sortDoneOn == 'done_lumis' && sortDoneOrder == -1" class="fa fa-sort-numeric-desc spacing-r sort-selected" title="Click to sort ascending by done lumisections"></i>
-          </button>
-          /
-          <button type="button" class="btn btn-sort m-2" ng-click="changeDoneSort('expected_lumis')">
-            <i ng-if="sortDoneOn != 'expected_lumis'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by expected lumisections"></i>
-            <i ng-if="sortDoneOn == 'expected_lumis' && sortDoneOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by expected lumisections"></i>
-            <i ng-if="sortDoneOn == 'expected_lumis' && sortDoneOrder == -1" class="fa fa-sort-numeric-desc spacing-r sort-selected" title="Click to sort ascending by expected lumisections"></i>
+          <button type="button" class="btn btn-sort m-2" ng-click="changeDoneSort('displayExpected')">
+            <i ng-if="sortDoneOn != 'displayExpected'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by expected events/lumisections"></i>
+            <i ng-if="sortDoneOn == 'displayExpected' && sortDoneOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by expected events/lumisections"></i>
+            <i ng-if="sortDoneOn == 'displayExpected' && sortDoneOrder == -1" class="fa fa-sort-numeric-desc spacing-r sort-selected" title="Click to sort ascending by expected events/lumisections"></i>
           </button>
         </div>
         <div class="col-sm-1">
-          <!-- Progress (Events) -->
-          <button type="button" class="btn btn-sort m-2" ng-click="changeDoneSort('percentage')">
-            <i ng-if="sortDoneOn != 'percentage'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by progress (based on events)"></i>
-            <i ng-if="sortDoneOn == 'percentage' && sortDoneOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by progress (based on events)"></i>
-            <i ng-if="sortDoneOn == 'percentage' && sortDoneOrder == -1" class="fa fa-sort-numeric-desc spacing-r sort-selected" title="Click to sort ascending by progress (based on events)"></i>
-          </button>
-        </div>
-        <div class="col-sm-1">
-          <!-- Progress (Lumisections) -->
-          <button type="button" class="btn btn-sort m-2" ng-click="changeDoneSort('percentageLumis')">
-            <i ng-if="sortDoneOn != 'percentageLumis'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by progress (based on lumis)"></i>
-            <i ng-if="sortDoneOn == 'percentageLumis' && sortDoneOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by progress (based on lumis)"></i>
-            <i ng-if="sortDoneOn == 'percentageLumis' && sortDoneOrder == -1" class="fa fa-sort-numeric-desc spacing-r sort-selected" title="Click to sort ascending by progress (based on lumis)"></i>
+          <button type="button" class="btn btn-sort m-2" ng-click="changeDoneSort('displayPercentage')">
+            <i ng-if="sortDoneOn != 'displayPercentage'" class="fa fa-sort-numeric-asc spacing-r" title="Click to sort ascending by progress"></i>
+            <i ng-if="sortDoneOn == 'displayPercentage' && sortDoneOrder == 1" class="fa fa-sort-numeric-asc spacing-r sort-selected" title="Click to sort descending by progress"></i>
+            <i ng-if="sortDoneOn == 'displayPercentage' && sortDoneOrder == -1" class="fa fa-sort-numeric-desc spacing-r sort-selected" title="Click to sort ascending by progress"></i>
           </button>
         </div>
         <div class="col-sm-2">
@@ -225,48 +159,23 @@
         </div>
       </div>
       <div ng-repeat="done in listDone" class="row zebra-lines small-padding">
-        <div class="col-sm-2">
+        <div class="col-sm-5">
           <a ng-href="{{done.url}}" target="_blank">{{done.prepid}}</a>
           <br><small>{{done.dataset}}</small>
           <small title="Number of events estimated from {{done.estimate_from}}" style="color:red" ng-if="done.estimate_from"><br>(Estimate from {{done.estimate_from}})</small>
         </div>
         <div class="col-sm-2">
-          <small>Events:</small><br>
-          <b title="{{done.done}}">{{humanReadable ? (done.done | readableNumbers) : done.done}}</b>
-          <small title="Force completed" style="color:red" ng-if="done.force_completed">(FC)</small>
-          /
-          <b title="{{done.expected}}">{{humanReadable ? (done.expected | readableNumbers) : done.expected}}</b>
-        </div>
-        <div class="col-sm-2">
-          <small>Lumisections:</small><br>
-          <b title="{{done.done_lumis}}">{{humanReadable ? (done.done_lumis | readableNumbers) : done.done_lumis}}</b>
-          <small title="Force completed" style="color:red" ng-if="done.force_completed">(FC)</small>
-          /
-          <b title="{{done.expected_lumis}}">{{humanReadable ? (done.expected_lumis | readableNumbers) : done.expected_lumis}}</b>
-        </div>
-        <div class="col-sm-1">
-          <!-- Progress (on events) -->
-          <small>Progress:</small><br>
-          <div class="progress total-bar" ng-show="done.expected > 0">
-            <div class="font-shadow progress-bar pmp-blue"
-                 ng-class="{'pmp-red': done.output_dataset_status == 'INVALID' || done.output_dataset_status == 'DELETED',
-                            'pmp-blue': done.output_dataset_status == 'VALID',
-                            'pmp-orange': done.output_dataset_status == 'PRODUCTION'}"
-                 role="progressbar"
-                 aria-valuemin="0"
-                 aria-valuemax="100"
-                 title="{{done.output_dataset}} is {{done.output_dataset_status}} at {{done.percentage | readableNumbers}}%"
-                 style="color: black;
-                        max-width: 100%;
-                        width:{{done.percentage}}%;">
-              {{done.percentage | readableNumbers}}%
-            </div>
+          <small>{{displayTitle}}:</small><br>
+          <div ng-show="done.displayExpected > 0">
+            <b title="{{done.displayDone}}">{{humanReadable ? (done.displayDone | readableNumbers) : done.displayDone}}</b>
+            <small title="Force completed" style="color:red" ng-if="done.force_completed">(FC)</small>
+            /
+            <b title="{{done.displayExpected}}">{{humanReadable ? (done.displayExpected | readableNumbers) : done.displayExpected}}</b>
           </div>
         </div>
         <div class="col-sm-1">
-          <!-- Progress (on lumisections) -->
           <small>Progress:</small><br>
-          <div class="progress total-bar" ng-show="done.expected > 0">
+          <div class="progress total-bar" ng-show="done.displayExpected > 0">
             <div class="font-shadow progress-bar pmp-blue"
                  ng-class="{'pmp-red': done.output_dataset_status == 'INVALID' || done.output_dataset_status == 'DELETED',
                             'pmp-blue': done.output_dataset_status == 'VALID',
@@ -274,11 +183,11 @@
                  role="progressbar"
                  aria-valuemin="0"
                  aria-valuemax="100"
-                 title="{{done.output_dataset}} is {{done.output_dataset_status}} at {{done.percentageLumis | readableNumbers}}%"
+                 title="{{done.output_dataset}} is {{done.output_dataset_status}} at {{done.displayPercentage | readableNumbers}}%"
                  style="color: black;
                         max-width: 100%;
-                        width:{{done.percentageLumis}}%;">
-              {{done.percentageLumis | readableNumbers}}%
+                        width:{{done.displayPercentage}}%;">
+              {{done.displayPercentage | readableNumbers}}%
             </div>
           </div>
         </div>


### PR DESCRIPTION
Fixes: #102 

1. Retrieve the expected lumisections from the ReqMgr2 workflow document and include them as `total_input_lumis`.
2. Retrieve the lumisections processed in the output datasets (via DBS) and set them in the latest history record. The older history records will have this field set as zero.
3. Include the required updates to replace ElasticSearch 6.8.9 for OpenSearch 2.11